### PR TITLE
Improve: Rotating pies section updates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -203,12 +203,18 @@
     flex: 0 0 auto;
     width: 180px;
     scroll-snap-align: start;
+    transition: transform 0.3s ease;
+  }
+
+  /* Hover effect for clickable pies */
+  .pie-item:hover {
+    transform: scale(1.05);
   }
 
   /* Rotating Pie Animation */
   .pie-spin {
-    animation: pieSpin 16s linear infinite;
-    animation-delay: calc(var(--i) * -0.7s);
+    animation: pieSpin 30s linear infinite;
+    animation-delay: calc(var(--i) * -1.2s);
     will-change: transform;
   }
 

--- a/components/sections/FeaturedPiesRow.tsx
+++ b/components/sections/FeaturedPiesRow.tsx
@@ -1,50 +1,67 @@
 'use client'
 
+import { useState } from 'react'
 import Image from 'next/image'
-
-const pies = [
-  { name: 'Apple Pie', image: 'https://images.unsplash.com/photo-1535920527002-b35e96722eb9?w=400&h=400&fit=crop' },
-  { name: 'Pecan Pie', image: 'https://images.unsplash.com/photo-1565958011703-44f9829ba187?w=400&h=400&fit=crop' },
-  { name: 'Cherry Pie', image: 'https://images.unsplash.com/photo-1464305795204-6f5bbfc7fb81?w=400&h=400&fit=crop' },
-  { name: 'Pumpkin Pie', image: 'https://images.unsplash.com/photo-1509461399763-ae67a981b254?w=400&h=400&fit=crop' },
-  { name: 'Blueberry Pie', image: 'https://images.unsplash.com/photo-1495147466023-ac5c588e2e94?w=400&h=400&fit=crop' },
-  { name: 'Peach Pie', image: 'https://images.unsplash.com/photo-1525351484163-7529414344d8?w=400&h=400&fit=crop' },
-  { name: 'Lemon Pie', image: 'https://images.unsplash.com/photo-1519915028121-7d3463d20b13?w=400&h=400&fit=crop' },
-  { name: 'Chocolate Pie', image: 'https://images.unsplash.com/photo-1578985545062-69928b1d9587?w=400&h=400&fit=crop' }
-]
+import Link from 'next/link'
+import { PieModal } from '@/components/ui/PieModal'
+import { pies, Pie } from '@/lib/data/pies'
 
 export function FeaturedPiesRow() {
+  const [selectedPie, setSelectedPie] = useState<Pie | null>(null)
+  const featuredPies = pies.slice(0, 8) // first 8 pies
+  
   return (
-    <section className="py-20 bg-dust-lightest">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-4xl md:text-5xl font-bold text-space-night mb-4">
-            🌟 Cosmic Favorites
-          </h2>
-          <p className="text-xl text-dust-medium mb-8">
-            Our most popular pies that keep Houstonians coming back
-          </p>
-        </div>
-        
-        <div className="pie-scroll-container">
-          {pies.map((pie, i) => (
-            <div key={pie.name} className="pie-item" style={{ '--i': i } as any}>
-              <div className="pie-spin">
-                <Image 
-                  src={pie.image} 
-                  alt={pie.name}
-                  width={180}
-                  height={180}
-                  className="rounded-full object-cover"
-                />
+    <>
+      <section className="py-20 bg-dust-lightest">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-12">
+            <h2 className="text-4xl md:text-5xl font-bold text-space-night mb-4">
+              Cosmic Favorites
+            </h2>
+            <p className="text-xl text-dust-medium mb-8">
+              Our most popular pies that keep Houstonians coming back
+            </p>
+          </div>
+          
+          <div className="pie-scroll-container">
+            {featuredPies.map((pie, i) => (
+              <div 
+                key={pie.id} 
+                className="pie-item cursor-pointer" 
+                style={{ '--i': i } as any}
+                onClick={() => setSelectedPie(pie)}
+              >
+                <div className="pie-spin">
+                  <Image 
+                    src={pie.image || '/pie-placeholder.svg'} 
+                    alt={pie.name}
+                    width={180}
+                    height={180}
+                    className="rounded-full object-cover"
+                  />
+                </div>
+                <p className="text-center mt-3 font-medium text-deep-navy text-sm">
+                  {pie.name}
+                </p>
               </div>
-              <p className="text-center mt-3 font-medium text-deep-navy text-sm">
-                {pie.name}
-              </p>
-            </div>
-          ))}
+            ))}
+          </div>
+          
+          <div className="text-center mt-12">
+            <Link href="/menu">
+              <button className="btn-primary px-8 py-4 text-lg">
+                View All Pies
+              </button>
+            </Link>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+      
+      <PieModal 
+        pie={selectedPie} 
+        isOpen={selectedPie !== null}
+        onClose={() => setSelectedPie(null)} 
+      />
+    </>
   )
 }

--- a/lib/data/pies.ts
+++ b/lib/data/pies.ts
@@ -1,3 +1,7 @@
+// TODO: Replace with actual transparent background aerial shots
+// User provided Google Photos links - need to download and add to public/images/pies/
+// Current images are placeholders - update with transparent background aerial pie shots
+
 export interface Pie {
   id: string
   name: string


### PR DESCRIPTION
Updates to rotating pies section based on feedback.

## Changes
- Removed star emoji from 'Cosmic Favorites' heading
- Added 'View All Pies' button below row (links to /menu)
- Made pies clickable - opens modal with details
- Slowed rotation from 16s to 30s for elegant spin
- Added hover scale effect
- Prepared structure for transparent background aerial images

## Notes
- Google Photos links require download - images can be added to public/images/pies/
- Using existing pie data structure from lib/data/pies.ts

## Testing
- Pies clickable, modal opens
- Rotation slower and elegant
- Button links to menu page
- Hover effects smooth