### PR TITLE
Fix: Reduce pie scale to preserve crust edge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -220,9 +220,9 @@
     border-radius: 9999px;
   }
 
-  /* Scale pie images to fill circular frame */
+  /* Scale pie images to align crust with circular border */
   .pie-spin img {
-    transform: scale(1.35);
+    transform: scale(1.15);
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
- Reduced scale from 1.35x to 1.15x
- Aligns pie crust with circular border instead of cutting it off
- Shows full pie without excessive background