### PR TITLE
Fix: Center logo composition vertically in hero

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -9,20 +9,21 @@ const SHOW_GUIDE = false
 const SHOW_VIEWPORT_INDICATOR = false
 
 // Tuning knobs - centralized positioning values
+// All elements centered vertically while maintaining relative spacing
 const POS = {
-  headlineTop: "10%",
+  headlineTop: "17.5%",
   headlineLeft: "0.5%",
   headlineWidth: "99%",
   
-  swooshTop: "24%",
+  swooshTop: "31.5%",
   swooshLeft: "0%",
   swooshWidth: "94%",
   
-  taglineTop: "34%",
+  taglineTop: "41.5%",
   taglineLeft: "35%",
   taglineWidth: "60%",
   
-  saucerBottom: "25%",
+  saucerBottom: "17.5%",
   saucerRight: "0.8%",
   saucerWidth: "41%",
 }


### PR DESCRIPTION
**Centered all 4 elements vertically while maintaining their relative spacing.**

**Changes:**
- headlineTop: 10% → 17.5% (+7.5%)
- swooshTop: 24% → 31.5% (+7.5%)
- taglineTop: 34% → 41.5% (+7.5%)
- saucerBottom: 25% → 17.5% (-7.5%)

**Result:** Logo composition is now centered at 50% vertical point of the stage, with all relative distances preserved.

**Hero sizing:**
- ✅  - takes full viewport height (standard for hero sections)
- ✅ Stage:  - portrait ratio matching logo
- ✅ Responsive widths: 520px → 640px → 760px max
- ✅ Vertically centered with 

Hero component size is appropriate for a landing page! 🎯