### PR TITLE
Remove cart and checkout functionality - informational site only

### DIFF
--- a/components/ui/Navigation.tsx
+++ b/components/ui/Navigation.tsx
@@ -3,8 +3,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { Logo } from './Logo'
-import { Button } from './Button'
-import { Menu, X, ShoppingCart } from 'lucide-react'
+import { Menu, X } from 'lucide-react'
 import { cn } from '@/lib/utils/cn'
 
 const navLinks = [
@@ -53,17 +52,10 @@ export function Navigation() {
                 {link.name}
               </Link>
             ))}
-            <Button size="sm" className="flex items-center gap-2">
-              <ShoppingCart size={18} />
-              <span>Order Now</span>
-            </Button>
           </div>
 
           {/* Mobile Menu Button */}
-          <div className="md:hidden flex items-center gap-4">
-            <button className="text-cosmic-orange p-2">
-              <ShoppingCart size={24} />
-            </button>
+          <div className="md:hidden">
             <button
               type="button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
@@ -95,9 +87,6 @@ export function Navigation() {
                   {link.name}
                 </Link>
               ))}
-              <div className="px-4 pt-2">
-                <Button className="w-full">Order Now</Button>
-              </div>
             </div>
           </div>
         )}

--- a/components/ui/PieCard.tsx
+++ b/components/ui/PieCard.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { Heart, Plus, ShoppingCart, Eye } from 'lucide-react'
+import { Heart, Eye } from 'lucide-react'
 import { Pie } from '@/lib/data/pies'
-import { Button } from './Button'
 import { cn } from '@/lib/utils/cn'
 import { useState } from 'react'
 
@@ -94,25 +93,6 @@ export function PieCard({ pie, index = 0, onClick }: PieCardProps) {
         <p className="text-sm text-dust-medium mb-4">
           Slice: ${pie.price.slice.toFixed(2)}
         </p>
-
-        {/* Actions */}
-        <div className="flex gap-2">
-          <Button 
-            className="flex-1 flex items-center justify-center gap-2"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <ShoppingCart size={18} />
-            <span>Add Whole</span>
-          </Button>
-          <Button 
-            variant="secondary" 
-            size="sm" 
-            className="px-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Plus size={18} />
-          </Button>
-        </div>
 
         {/* Additional Info */}
         {pie.canFreeze && (

--- a/components/ui/PieModal.tsx
+++ b/components/ui/PieModal.tsx
@@ -2,9 +2,8 @@
 
 import { useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { X, ShoppingCart } from 'lucide-react'
+import { X } from 'lucide-react'
 import { Pie } from '@/lib/data/pies'
-import { Button } from './Button'
 
 interface PieModalProps {
   pie: Pie | null
@@ -216,21 +215,6 @@ export function PieModal({ pie, isOpen, onClose }: PieModalProps) {
                       </div>
                     </div>
                   </div>
-
-                  {/* Actions */}
-                  <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-dust-light">
-                    <Button className="flex-1 flex items-center justify-center gap-2">
-                      <ShoppingCart size={20} />
-                      <span>Add Whole Pie</span>
-                    </Button>
-                    <Button variant="secondary" className="flex-1">
-                      Add Slice
-                    </Button>
-                  </div>
-
-                  <p className="text-xs text-dust-medium text-center mt-3">
-                    * Cart functionality coming soon
-                  </p>
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
Removed all cart and checkout functionality as the site is informational only for now.

**Removed:**
- Cart button from navigation header (desktop + mobile)
- "Order Now" buttons from navigation
- "Add to Cart" / "Add Whole Pie" / "Add Slice" buttons from pie cards
- Cart action buttons from pie modal
- Cart functionality notice text

**Kept:**
- ✅ All pricing information (whole pie and slice prices)
- ✅ Pie details and descriptions
- ✅ "View Details" modal functionality
- ✅ Favorite heart button

**Files updated:**
- `components/ui/Navigation.tsx` - removed cart button and Order Now buttons
- `components/ui/PieModal.tsx` - removed action buttons
- `components/ui/PieCard.tsx` - removed cart buttons

Site is now purely informational with pricing for reference.