### PR TITLE
Adjust Animation Timing - Saucer Appears When Swoosh Finishes

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -69,12 +69,12 @@ export function HeroSection() {
     // Sequential animation phases
     const timeline = async () => {
       await delay(200)
-      setAnimationPhase(1) // Swoosh starts drawing
+      setAnimationPhase(1) // Swoosh starts drawing (duration: 1.2s)
       
       await delay(400)
       setAnimationPhase(2) // Headline fades in (while swoosh continues)
       
-      await delay(1200)
+      await delay(800) // Adjusted: Saucer appears right when swoosh finishes (200 + 1200 = 1400ms)
       setAnimationPhase(3) // Saucer lands
       
       await delay(400)


### PR DESCRIPTION
## ⏱️ Timing Adjustment

Fixes the delay between swoosh finishing and saucer appearing. The saucer now arrives exactly when the swoosh finishes drawing.

---

## Problem

- Swoosh finishes at **1400ms** (200ms start + 1200ms animation)
- Saucer appeared at **1800ms**
- **400ms gap** created an awkward pause

---

## Solution

- Adjusted delay before saucer from **1200ms → 800ms**
- Saucer now appears at exactly **1400ms**
- Perfect sync: saucer arrives right when swoosh finishes ✨

---

## New Timeline

```
0ms    → Start
200ms  → Swoosh starts drawing (1.2s animation)
600ms  → Headline fades in
1400ms → Swoosh finishes AND saucer appears (no gap!)
1800ms → Tagline fades in
```

---

## Effect

Creates the feeling that the saucer **arrived with the swoosh**, rather than appearing after a pause. Much tighter and more polished!

---

**Ready to merge!** 🚀