### PR TITLE
Sync Saucer and Tagline Timing + Eliminate Delay

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -62,7 +62,7 @@ export function HeroSection() {
     
     if (!ENABLE_ANIMATION || prefersReducedMotion) {
       // Skip animation, show final state
-      setAnimationPhase(4)
+      setAnimationPhase(3)
       return
     }
 
@@ -74,11 +74,8 @@ export function HeroSection() {
       await delay(400)
       setAnimationPhase(2) // Headline fades in (while swoosh continues)
       
-      await delay(800) // Adjusted: Saucer appears right when swoosh finishes (200 + 1200 = 1400ms)
-      setAnimationPhase(3) // Saucer lands
-      
-      await delay(400)
-      setAnimationPhase(4) // Tagline fades in
+      await delay(700) // Saucer + tagline appear together slightly before swoosh finishes
+      setAnimationPhase(3) // Saucer lands + tagline fades in simultaneously
     }
 
     timeline()
@@ -283,7 +280,7 @@ export function HeroSection() {
             {/* Tagline: Our Pies Are / Out Of This World! */}
             <div 
               className={`absolute text-center transition-all duration-700 ${
-                animationPhase >= 4 ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+                animationPhase >= 3 ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
               }`}
               style={{ 
                 top: POS.taglineTop, 


### PR DESCRIPTION
## ⏱️ Timing Improvements

Fixes both issues from feedback:
1. Eliminates perceived delay between swoosh and saucer
2. Saucer and tagline now appear simultaneously

---

## Changes

### 1️⃣ Saucer Appears 100ms Earlier
- **Before:** 1400ms (exactly when swoosh finishes)
- **After:** 1300ms (slightly before swoosh finishes)
- **Result:** No perceived delay - smoother transition

### 2️⃣ Saucer + Tagline Appear Together
- **Before:** Saucer at 1400ms, tagline at 1800ms (400ms gap)
- **After:** Both at 1300ms (simultaneous)
- **Result:** Unified reveal moment

---

## New Timeline

```
0ms    → Start
200ms  → Swoosh starts drawing (1.2s animation)
600ms  → Headline fades in
1300ms → Saucer + tagline appear together 🛸
1400ms → Swoosh finishes (100ms overlap)
```

**Total animation:** 1.3 seconds (down from 1.8s)

---

## Why This Works Better

### Overlap Effect
By having saucer appear 100ms before swoosh finishes, there's a **subtle overlap** that eliminates any perceived pause. The swoosh is still drawing when saucer appears, creating a seamless transition.

### Simultaneous Reveal
Saucer and tagline appearing together creates a **unified moment** rather than two separate reveals. Feels more polished and intentional.

---

## Code Changes

- Reduced delay before phase 3 from 800ms to 700ms
- Changed tagline condition from `phase >= 4` to `phase >= 3`
- Removed separate phase 4 (consolidated into phase 3)
- Updated initial state from 4 to 3

---

**Ready to merge!** Much tighter animation now. 🚀