### PR TITLE
Make Saucer Appear During Swoosh Animation (Not After)

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -69,12 +69,12 @@ export function HeroSection() {
     // Sequential animation phases
     const timeline = async () => {
       await delay(200)
-      setAnimationPhase(1) // Swoosh starts drawing (duration: 1.2s)
+      setAnimationPhase(1) // Swoosh starts drawing (duration: 1.2s, finishes at 1400ms)
       
       await delay(400)
       setAnimationPhase(2) // Headline fades in (while swoosh continues)
       
-      await delay(700) // Saucer + tagline appear together slightly before swoosh finishes
+      await delay(400) // Saucer + tagline appear at 1000ms (during swoosh, not after)
       setAnimationPhase(3) // Saucer lands + tagline fades in simultaneously
     }
 


### PR DESCRIPTION
## ⏱️ Eliminate Perceived Delay

User feedback: Still seeing a delay after swoosh finishes before saucer appears.

---

## Root Cause

Previous timing:
- Saucer appeared at **1300ms**
- Swoosh finished at **1400ms**
- Only **100ms overlap** wasn't enough to eliminate perceived delay

---

## Solution

Moved saucer appearance much earlier:
- Saucer now appears at **1000ms**
- Swoosh finishes at **1400ms**
- **400ms overlap** - saucer clearly appears **during** the swoosh, not near the end

---

## New Timeline

```
0ms    → Start
200ms  → Swoosh starts drawing (1.2s animation)
600ms  → Headline fades in
1000ms → Saucer + tagline appear (MID-SWOOSH) 🛸
1400ms → Swoosh finishes
```

**Total animation:** 1.0 seconds to full reveal

---

## Why This Works

### During vs After
By having the saucer appear **400ms before** the swoosh finishes, it's clearly appearing **during** the swoosh animation, not waiting for it to complete. This creates a more dynamic, fluid feel.

### Perception
Even though the previous version had a 100ms overlap, it felt like "waiting" because the saucer appeared near the end. Now it appears mid-animation, which feels much more natural.

---

**Ready to merge!** This should completely eliminate the perceived delay. 🚀