### PR TITLE
Fix Hero Height & Simplify Scroll Arrow

### DIFF
--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -85,7 +85,7 @@ export function HeroSection() {
   const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
   return (
-    <section className="hero-retro-background relative w-full min-h-screen flex items-center justify-center overflow-hidden py-8">
+    <section className="hero-retro-background relative w-full h-screen flex items-center justify-center overflow-hidden">
       {/* CSS Variables for Responsive Font Sizes */}
       <style jsx>{`
         /* === RETRO HERO BACKGROUND (background-only changes) === */

--- a/components/ui/ScrollIndicator.tsx
+++ b/components/ui/ScrollIndicator.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { ChevronDown } from 'lucide-react'
-
 interface ScrollIndicatorProps {
   visible: boolean
 }
@@ -32,17 +30,18 @@ export function ScrollIndicator({ visible }: ScrollIndicatorProps) {
         }
       }}
     >
-      <div className="flex flex-col items-center gap-2">
-        <span className="text-xs font-display font-medium text-accent uppercase tracking-wider">
-          Scroll
-        </span>
-        <div className="scroll-bounce">
-          <ChevronDown 
-            size={32} 
-            className="text-accent"
-            strokeWidth={2.5}
-          />
-        </div>
+      <div className="scroll-bounce">
+        <svg
+          className="w-6 h-6 mx-auto"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          stroke="#020169"
+        >
+          <path d="M19 14l-7 7m0 0l-7-7m7 7V3"></path>
+        </svg>
       </div>
     </div>
   )


### PR DESCRIPTION
## 🔧 Hero Fixes

Based on user feedback:

---

## 1️⃣ Hero Height Fixed

### Problem
- Hero was extending below viewport
- Used `min-h-screen` + `py-8` padding
- Scroll arrow was cut off
- Didn't match portfolio behavior

### Solution
- Changed to `h-screen` (exactly viewport height)
- Removed `py-8` padding
- Hero now takes up **exactly** visible space

---

## 2️⃣ Scroll Arrow Simplified

### Before
- Text + arrow ("Scroll" + ChevronDown)
- Accent color
- More complex design

### After (matching portfolio)
- **Just arrow** (no text)
- **Heading text color** (#020169 - same as "FLYING SAUCER")
- Same SVG path as portfolio: `M19 14l-7 7m0 0l-7-7m7 7V3`
- w-6 h-6 size
- Maintains bounce animation
- Fully accessible (keyboard, ARIA)

---

## Result

✅ Hero is exactly viewport height  
✅ Scroll arrow visible at bottom  
✅ Arrow matches portfolio style  
✅ No content extending below viewport  
✅ Clean, minimal design

---

## Next Steps

After merge, will adjust logo vertical positioning to reduce gap below header if needed.

---

**Ready to merge!** 🚀