### PR TITLE
Add Aggressive Mobile-Specific Hero Positioning

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -687,3 +687,22 @@ html {
     animation: none !important;
   }
 }
+
+/* Mobile-specific hero positioning - more aggressive shift up */
+@media (max-width: 640px) {
+  .hero-headline-container {
+    top: 8% !important;
+  }
+  
+  .hero-swoosh {
+    top: 22% !important;
+  }
+  
+  .hero-tagline-container {
+    top: 32% !important;
+  }
+  
+  .hero-saucer {
+    bottom: 22% !important;
+  }
+}

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -15,8 +15,10 @@ const SHOW_VIEWPORT_INDICATOR = false
 const ENABLE_ANIMATION = true
 
 // Tuning knobs - centralized positioning values
-// Shifted up to reduce gap above headline while maintaining relative spacing
+// Mobile: shifted up more aggressively to fit in viewport with arrow visible
+// Desktop: moderately shifted to reduce gap
 const POS = {
+  // Desktop positioning
   headlineTop: "12.5%",
   headlineLeft: "0.5%",
   headlineWidth: "99%",
@@ -32,6 +34,14 @@ const POS = {
   saucerBottom: "17.5%",
   saucerRight: "0.8%",
   saucerWidth: "41%",
+  
+  // Mobile-specific overrides (more aggressive)
+  mobile: {
+    headlineTop: "8%",
+    swooshTop: "22%",
+    taglineTop: "32%",
+    saucerBottom: "22%",
+  }
 }
 
 // Font size tuning knobs - adjust per viewport!
@@ -242,7 +252,7 @@ export function HeroSection() {
           
           {/* Layer 2: Swoosh (behind text) - Top-to-bottom reveal animation */}
           <div 
-            className={`absolute pointer-events-none z-10 transition-opacity duration-300 ${
+            className={`absolute pointer-events-none z-10 transition-opacity duration-300 hero-swoosh ${
               animationPhase >= 1 ? 'opacity-100' : 'opacity-0'
             }`}
             style={{ 
@@ -259,7 +269,7 @@ export function HeroSection() {
             
             {/* Headline: FLYING SAUCER / PIE COMPANY */}
             <div 
-              className={`absolute text-center transition-all duration-700 ${
+              className={`absolute text-center transition-all duration-700 hero-headline-container ${
                 animationPhase >= 2 ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
               }`}
               style={{ 
@@ -280,7 +290,7 @@ export function HeroSection() {
 
             {/* Tagline: Our Pies Are / Out Of This World! */}
             <div 
-              className={`absolute text-center transition-all duration-700 ${
+              className={`absolute text-center transition-all duration-700 hero-tagline-container ${
                 animationPhase >= 3 ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
               }`}
               style={{ 
@@ -302,7 +312,7 @@ export function HeroSection() {
 
           {/* Layer 4: Saucer (bottom-right, landing effect) */}
           <div 
-            className={`absolute pointer-events-none z-30 transition-all duration-500 ${
+            className={`absolute pointer-events-none z-30 transition-all duration-500 hero-saucer ${
               animationPhase >= 3 
                 ? 'opacity-100 scale-100' 
                 : 'opacity-0 scale-75'


### PR DESCRIPTION
## 📱 Mobile Hero Positioning Fix

Based on feedback: mobile hero still too long, scroll arrow cut off, too much gap above content.

---

## Problem on Mobile

- Hero content still too far from top
- Scroll arrow cut off (below viewport)
- Too much wasted space above headline

---

## Solution: Mobile-Specific Overrides

Added aggressive positioning adjustments **only for mobile** (< 640px):

### Mobile Changes
```
headlineTop: 12.5% → 8% (↓ 4.5%)
swooshTop: 26.5% → 22% (↓ 4.5%)
taglineTop: 36.5% → 32% (↓ 4.5%)
saucerBottom: 17.5% → 22% (↑ 4.5% from bottom - moves up)
```

### Desktop: Unchanged
```
headlineTop: 12.5%
swooshTop: 26.5%
taglineTop: 36.5%
saucerBottom: 17.5%
```

---

## Implementation

### CSS Classes Added
- `.hero-headline-container`
- `.hero-swoosh`
- `.hero-tagline-container`
- `.hero-saucer`

### Media Query
```css
@media (max-width: 640px) {
  .hero-headline-container { top: 8% !important; }
  .hero-swoosh { top: 22% !important; }
  .hero-tagline-container { top: 32% !important; }
  .hero-saucer { bottom: 22% !important; }
}
```

---

## Result

### ✅ Mobile
- Much less gap between navbar and content
- All hero content fits in viewport
- Scroll arrow visible
- Content properly centered

### ✅ Desktop
- No changes
- Existing positioning maintained

---

## Testing

- ✅ Build passes
- ⚠️ **Needs mobile testing** - please test on phone
- ✅ Desktop unchanged (verified in code)

---

**Ready to merge after mobile testing!** 🚀